### PR TITLE
feat: generating the cart summary automatically

### DIFF
--- a/apps/billing/src/app/shopping/cart/cart-table/cart-table.component.html
+++ b/apps/billing/src/app/shopping/cart/cart-table/cart-table.component.html
@@ -9,36 +9,38 @@
     </tr>
   </thead>
   <tbody class="list">
-    <tr *ngFor="let cartItem of cs.getCartItems()">
-      <th scope="row">
-        <div class="col align-items-center">
-          <div class="lh-100">
-            <span class="text-dark font-weight-bold mb-0">{{ cartItem?.item?.service }}</span>
+    <ng-container *ngIf="data.length > 0">
+      <tr *ngFor="let cartItem of data">
+        <th scope="row">
+          <div class="col align-items-center">
+            <div class="lh-100">
+              <span class="text-dark font-weight-bold mb-0">{{ cartItem?.item?.service }}</span>
+            </div>
+            <span class="font-weight-bold text-muted">{{ cartItem?.item?.description }}</span>
           </div>
-          <span class="font-weight-bold text-muted">{{ cartItem?.item?.description }}</span>
-        </div>
-      </th>
-      <td class="price">
-        {{ cartItem?.item?.price | currency:'AOA' }}
-      </td>
-      <td>
-        <input type="number" class="form-control form-control-sm text-center w-80" #i
-          (change)="cs.updateCartItemQty(cartItem, i.value)" min="1" [value]="cartItem?.quantity">
-      </td>
-      <td class="total">
-        {{ (cartItem?.item?.price * cartItem?.quantity) | currency:'AOA' }}
-      </td>
-      <td class="text-right">
-        <div class="actions ml-3">
-          <a href="javascript:void(0)" class="action-item mr-2" data-toggle="tooltip" title="Visualizar item">
-            <i class="far fa-external-link-alt"></i>
-          </a>
-          <a href="javascript:void(0)" (click)="cs.unsetCartItem(cartItem)" class="action-item mr-2"
-            data-toggle="tooltip" title="Remover da Bolsa">
-            <i class="far fa-times"></i>
-          </a>
-        </div>
-      </td>
-    </tr >
+        </th>
+        <td class="price">
+          {{ cartItem?.item?.price | currency:'AOA' }}
+        </td>
+        <td>
+          <input type="number" class="form-control form-control-sm text-center w-80" #i
+            (change)="update(cartItem, i.value)" min="1" [value]="cartItem?.quantity">
+        </td>
+        <td class="total">
+          {{ (cartItem?.item?.price * cartItem?.quantity) | currency:'AOA' }}
+        </td>
+        <td class="text-right">
+          <div class="actions ml-3">
+            <a href="javascript:void(0)" class="action-item mr-2" data-toggle="tooltip" title="Visualizar item">
+              <i class="far fa-external-link-alt"></i>
+            </a>
+            <a href="javascript:void(0)" (click)="unset(cartItem)" class="action-item mr-2"
+              data-toggle="tooltip" title="Remover da Bolsa">
+              <i class="far fa-times"></i>
+            </a>
+          </div>
+        </td>
+      </tr>
+    </ng-container>
   </tbody>
 </table>

--- a/apps/billing/src/app/shopping/cart/cart-table/cart-table.component.html
+++ b/apps/billing/src/app/shopping/cart/cart-table/cart-table.component.html
@@ -22,23 +22,23 @@
         {{ cartItem?.item?.price | currency:'AOA' }}
       </td>
       <td>
-        <input type="number" class="form-control form-control-sm text-center w-80" [value]="cartItem?.quantity">
+        <input type="number" class="form-control form-control-sm text-center w-80" #i
+          (change)="cs.updateCartItemQty(cartItem, i.value)" min="1" [value]="cartItem?.quantity">
       </td>
       <td class="total">
         {{ (cartItem?.item?.price * cartItem?.quantity) | currency:'AOA' }}
       </td>
       <td class="text-right">
-
         <div class="actions ml-3">
           <a href="javascript:void(0)" class="action-item mr-2" data-toggle="tooltip" title="Visualizar item">
             <i class="far fa-external-link-alt"></i>
           </a>
-          <a href="javascript:void(0)" (click)="cs.unsetCartItem(cartItem)" class="action-item mr-2" data-toggle="tooltip"
-            title="Remover da Bolsa">
+          <a href="javascript:void(0)" (click)="cs.unsetCartItem(cartItem)" class="action-item mr-2"
+            data-toggle="tooltip" title="Remover da Bolsa">
             <i class="far fa-times"></i>
           </a>
         </div>
       </td>
-    </tr>
+    </tr >
   </tbody>
 </table>

--- a/apps/billing/src/app/shopping/cart/cart-table/cart-table.component.spec.ts
+++ b/apps/billing/src/app/shopping/cart/cart-table/cart-table.component.spec.ts
@@ -2,27 +2,25 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CartTableComponent } from './cart-table.component';
 import { By } from '@angular/platform-browser';
-import { CartItem } from '@businx/data-models';
+import { ICartItem } from '../cart.model';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 describe('CartTableComponent', () => {
   let component: CartTableComponent;
   let fixture: ComponentFixture<CartTableComponent>;
-  const demo: CartItem = {
-    id: 1,
-    item:{
-      id: 'zyx',
+  const demo: ICartItem = new ICartItem({
+      id: 123,
       service: 'service name',
       description: 'Loren ipsum, dolet amet rusir.',
       price: 5000,
       type: 'tech',
       buyInfo: false
-    },
-    quantity: 1,
-  }
+    }, 1, false);
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ CartTableComponent ]
+      declarations: [ CartTableComponent ],
+      schemas: [ NO_ERRORS_SCHEMA ]
     })
     .compileComponents();
   }));
@@ -30,19 +28,24 @@ describe('CartTableComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(CartTableComponent);
     component = fixture.componentInstance;
+
+    component.data.push(demo);
+    component.onUpdate = null;
+    component.onDelete = null;
+
     fixture.detectChanges();
   });
 
   it('has five (5) head columns', () => {
-    const th = fixture.debugElement.queryAll(By.css('thead > tr > th'));
-    
+    const th = fixture.debugElement.queryAll(By.css('.table thead > tr > th'));
+
     expect(component).toBeTruthy();
     expect(th.length).toBe(5);
   });
 
   it('has the correct columns names', () => {
-    const th = fixture.debugElement.queryAll(By.css('thead > tr > th'));
-    
+    const th = fixture.debugElement.queryAll(By.css('.table > thead > tr > th'));
+
     expect(th[0].nativeElement.textContent).toBe('Producto');
     expect(th[1].nativeElement.textContent).toBe('Preço');
     expect(th[2].nativeElement.textContent).toBe('Quantidade');
@@ -51,16 +54,10 @@ describe('CartTableComponent', () => {
   });
 
   it('has a actions-menu that helps manage items inside the cart', () => {
-    component.docs = [demo];
-
-    fixture.detectChanges();
-
     const a = fixture.debugElement.queryAll(By.css('.actions > a'));
 
     expect(a.length).toBe(2);
     expect(a[0].nativeElement.innerHTML).toBe(`<i class="far fa-external-link-alt"></i>`);
     expect(a[1].nativeElement.innerHTML).toBe(`<i class="far fa-times"></i>`);
   });
-
-  it('should remove the item safely.', () => {});
 });

--- a/apps/billing/src/app/shopping/cart/cart-table/cart-table.component.ts
+++ b/apps/billing/src/app/shopping/cart/cart-table/cart-table.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit, Input } from '@angular/core';
-import { CartService } from '../cart.service';
+import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
+import { ICartItem } from '../cart.model';
 
 @Component({
   selector: 'businx-cart-table',
@@ -12,9 +12,21 @@ import { CartService } from '../cart.service';
 })
 export class CartTableComponent implements OnInit {
 
-  constructor(public cs: CartService) { }
+  @Input('data') data: ICartItem [];
+  @Output('onUpdate') onUpdate = new EventEmitter<[ICartItem, number]>();
+  @Output('onDelete') onDelete = new EventEmitter<ICartItem>();
+
+  constructor() { }
 
   ngOnInit() {
+  }
+
+  unset(item: ICartItem) {
+    this.onDelete.emit(item);
+  }
+
+  update(item: ICartItem, newVal: number) {
+    this.onUpdate.emit([item, newVal]);
   }
 
 }

--- a/apps/billing/src/app/shopping/cart/cart.component.html
+++ b/apps/billing/src/app/shopping/cart/cart.component.html
@@ -46,7 +46,11 @@
     </div>
   </div>
   <div class="table-responsive">
-    <businx-cart-table></businx-cart-table>
+    <businx-cart-table
+    [data]="cs.getCartItems()"
+    (onDelete)="onDelete($event)"
+    (onUpdate)="onUpdate($event)"
+    ></businx-cart-table>
   </div>
   <div class="card-body">
     <businx-summary></businx-summary>

--- a/apps/billing/src/app/shopping/cart/cart.component.spec.ts
+++ b/apps/billing/src/app/shopping/cart/cart.component.spec.ts
@@ -1,11 +1,14 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { CartComponent } from './cart.component';
-import { CartTableComponent } from './cart-table/cart-table.component';
-import { SummaryComponent } from './summary/summary.component';
-import { ModalItemListComponent } from './modal-item-list/modal-item-list.component';
 import { By } from '@angular/platform-browser';
 import { SharedModule } from '@businx/billing/shared/shared.module';
+import { CartTableComponent } from './cart-table/cart-table.component';
+import { CartComponent } from './cart.component';
+import { ContactsListModalComponent } from './contacts-list-modal/contacts-list-modal.component';
+import { ModalItemListComponent } from './modal-item-list/modal-item-list.component';
+import { SummaryComponent } from './summary/summary.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ContactCardComponent } from '@businx/billing/shared/contact-card/contact-card.component';
+
 
 describe('🚦 Cart [Page]', () => {
   let component: CartComponent;
@@ -20,9 +23,10 @@ describe('🚦 Cart [Page]', () => {
         CartComponent,
         CartTableComponent,
         ModalItemListComponent,
-        SummaryComponent
+        SummaryComponent,
+        ContactsListModalComponent
       ],
-      imports: [ SharedModule ]
+      imports: [ SharedModule, RouterTestingModule ]
     })
     .compileComponents();
   }));
@@ -36,7 +40,9 @@ describe('🚦 Cart [Page]', () => {
     expect(component).toBeTruthy();
   });
 
-  it('has client info', () => {});
+  it('should have a client info', () => {
+
+  });
 
   it('display\'s the invoice/order info', () => {
 

--- a/apps/billing/src/app/shopping/cart/cart.component.ts
+++ b/apps/billing/src/app/shopping/cart/cart.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { CartService } from './cart.service';
 import { Router } from '@angular/router';
+import { ICartItem } from './cart.model';
 
 @Component({
   selector: 'businx-cart',
@@ -16,6 +17,16 @@ export class CartComponent implements OnInit {
 
   checkout() {
     this.route.navigate(['/shopping/checkout'])
+  }
+
+  onDelete($event: ICartItem) {
+    this.cs.unsetCartItem($event);
+  }
+
+  onUpdate($event: [ICartItem, number]) {
+    const [ item, newVal] = $event;
+
+    this.cs.updateCartItemQty(item, newVal);
   }
 
   ngOnInit() {

--- a/apps/billing/src/app/shopping/cart/cart.service.ts
+++ b/apps/billing/src/app/shopping/cart/cart.service.ts
@@ -58,6 +58,20 @@ export class CartService {
     }
   }
 
+  updateCartItemQty(obj: ICartItem, qty: number) {
+    const cartItems: ICartItem[] = this.getCartItems();
+
+    if (cartItems.length > 0) {
+      cartItems.forEach(val => {
+        if (obj.item.id == val.item.id) {
+          val.quantity = qty;
+        }
+      });
+    }
+
+    return this.setLocalStorage(this.itemsStore, cartItems);
+  }
+
   unsetCartItem(obj: ICartItem) {
     const cartItems: ICartItem [] = this.getCartItems();
 
@@ -74,30 +88,51 @@ export class CartService {
     localStorage.removeItem(this.itemsStore);
   }
 
-  /** HANDLERS **/
-
-  getSubtotal(arr: ICartItem []): number {
+  getSubtotal(): number {
+    const cartItems: ICartItem [] = this.getCartItems();
     let subtotal = 0;
 
-    arr.find((val) => {
-      subtotal += (val.item.price * val.quantity);
-    });
+    if (cartItems.length > 0) {
+      cartItems.find((obj) => {
+        subtotal += (obj.item.price * obj.quantity);
+      });
+    }
 
     return subtotal;
   }
 
-  getTax(arr: ICartItem []) {
+  getTax() {
+    const cartItems: ICartItem [] = this.getCartItems();
     let tax = 0;
 
-    arr.find((val) => {
-      tax += (val.item.price * 0.14);
-    });
+    if (cartItems.length > 0) {
+      cartItems.find((obj) => {
+        const { item:{ price }, quantity } = obj;
+
+        tax += ((price * quantity) * 0.14);
+      });
+    }
 
     return tax;
   }
 
-  getTotal(subtotal, ship, tax) {
-    return (subtotal + ship + tax);
+  getTotal(ship: number, discount: number) {
+    const cost = (this.getSubtotal() + this.getTax() + ship);
+
+    if (discount === 0)
+      return cost;
+
+    return (cost - ((cost * discount) / 100));
+  }
+
+  setToLocalStorage(key: string, obj: any) {
+    this.setLocalStorage(key, obj);
+  }
+
+  getFromLocalStorage(key: string, aliase) {
+    const ls = localStorage.getItem(key);
+
+    return ls === null ? aliase : JSON.parse(ls);
   }
 
   private setLocalStorage(key: string, obj: any) {

--- a/apps/billing/src/app/shopping/cart/summary/summary.component.html
+++ b/apps/billing/src/app/shopping/cart/summary/summary.component.html
@@ -1,34 +1,63 @@
 <div class="row mt-3 pt-3 border-top">
-  <div class="col-8 text-right">
+  <div class="col-lg-8 text-right">
     <small class="font-weight-bold">Subtotal:</small>
   </div>
-  <div class="col-4 text-right">
-    <span id="subtotal" class="text-sm font-weight-bold">{{ 12900 | currency:'AOA' }}</span>
+  <div class="col-lg-4 text-right">
+    <span id="subtotal" class="text-sm font-weight-bold">
+      {{ cs.getSubtotal() | currency:'AOA' }}
+    </span>
   </div>
 </div>
 
-<div class="row mt-3 pt-3 border-top">
-  <div class="col-8 text-right">
+<div class="row mt-3 pt-3 border-top align-items-center">
+  <div class="col-lg-8 text-right">
+    <small class="font-weight-bold mb-0">Desconto (máx 30%):</small>
+  </div>
+  <div class="col-lg-4 d-flex justify-content-end">
+    <input class="form-control form-control-sm" style="width: 100px;" type="number" id="discount"
+      (change)="checkDiscountLimit()" [(ngModel)]="discount">
+  </div>
+</div>
+
+<div class="row mt-3 pt-3 border-top align-items-center">
+  <div class="col-lg-8 text-right">
     <div class="media align-items-center">
       <i class="far fa-shipping-fast"></i>
       <div class="media-body">
         <div class="text-limit lh-100">
-          <small class="font-weight-bold mb-0">Taxa de envio:</small>
+          <small class="font-weight-bold mb-0">Taxa de entrega:</small>
         </div>
-        <small id="ship" class="badge badge-success">Entrega digital</small>
+        <small *ngIf="ship === 0" id="ship" class="badge badge-success">Entrega digital</small>
+        <small *ngIf="ship !== 0">
+          <i class="far fa-coins mr-1"></i> AKZ
+        </small>
       </div>
     </div>
   </div>
-  <div class="col-4 text-right">
-    <span id="ship_coast" class="text-sm font-weight-bold">{{ 0 | currency:'AOA' }}</span>
+  <div class="col-lg-4 d-flex justify-content-end">
+    <input class="form-control form-control-sm" style="width: 100px;" type="number" id="ship_coast"
+      [(ngModel)]="ship" (change)="cs.setToLocalStorage('CART_SHIP', ship)">
   </div>
 </div>
 
 <div class="row mt-3 pt-3 border-top">
-  <div class="col-8 text-right">
+  <div class="col-lg-8 text-right">
+    <small class="font-weight-bold mb-0">Imposto (IVA - 14%):</small>
+  </div>
+  <div class="col-lg-4 text-right">
+    <span id="total" class="text-sm font-weight-bold">
+      {{ cs.getTax() | currency:'AOA' }}
+    </span>
+  </div>
+</div>
+
+<div class="row mt-3 pt-3 border-top">
+  <div class="col-lg-8 text-right">
     <small class="text-uppercase font-weight-bold">Total:</small>
   </div>
-  <div class="col-4 text-right">
-    <span id="total" class="text-sm font-weight-bold">{{ 12900 | currency:'AOA' }}</span>
+  <div class="col-lg-4 text-right">
+    <span id="total" class="text-sm font-weight-bold">
+      {{ cs.getTotal(ship, discount) | currency:'AOA' }}
+    </span>
   </div>
 </div>

--- a/apps/billing/src/app/shopping/cart/summary/summary.component.spec.ts
+++ b/apps/billing/src/app/shopping/cart/summary/summary.component.spec.ts
@@ -2,6 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SummaryComponent } from './summary.component';
 import { By } from '@angular/platform-browser';
+import { FormsModule } from '@angular/forms';
 
 describe('SummaryComponent', () => {
   let component: SummaryComponent;
@@ -9,7 +10,10 @@ describe('SummaryComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ SummaryComponent ]
+      declarations: [ SummaryComponent ],
+      imports: [
+        FormsModule
+      ]
     })
     .compileComponents();
   }));
@@ -27,8 +31,8 @@ describe('SummaryComponent', () => {
 
     expect(els).toBeTruthy();
     expect(els[0].nativeElement.textContent).toContain('Subtotal:');
-    expect(els[1].nativeElement.textContent).toContain('Taxa de envio:');
-    expect(els[3].nativeElement.textContent).toContain('Total:');
+    expect(els[2].nativeElement.textContent).toContain('Taxa de entrega:');
+    expect(els[5].nativeElement.textContent).toContain('Total:');
   });
 
   it(`shall display the subtotal & total values in 'AOA' coin`, () => {

--- a/apps/billing/src/app/shopping/cart/summary/summary.component.ts
+++ b/apps/billing/src/app/shopping/cart/summary/summary.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { CartService } from '../cart.service';
 
 @Component({
   selector: 'businx-summary',
@@ -7,7 +8,17 @@ import { Component, OnInit } from '@angular/core';
 })
 export class SummaryComponent implements OnInit {
 
-  constructor() { }
+  ship = this.cs.getFromLocalStorage('CART_SHIP', 0);
+  discount = this.cs.getFromLocalStorage('CART_DISCOUNT', 0);;
+
+  constructor(public cs: CartService) { }
+
+  checkDiscountLimit() {
+    if (this.discount > 30)
+      this.discount = 30
+
+    this.cs.setToLocalStorage('CART_DISCOUNT', this.discount);
+  }
 
   ngOnInit() {
   }

--- a/apps/billing/src/app/shopping/checkout/checkout.component.spec.ts
+++ b/apps/billing/src/app/shopping/checkout/checkout.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CheckoutComponent } from './checkout.component';
+import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 describe('CheckoutComponent', () => {
   let component: CheckoutComponent;
@@ -8,7 +9,8 @@ describe('CheckoutComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ CheckoutComponent ]
+      declarations: [ CheckoutComponent ],
+      schemas: [ NO_ERRORS_SCHEMA ]
     })
     .compileComponents();
   }));


### PR DESCRIPTION
## Enhancements:
1. Enable _data persistence_ to Local storage automatically when user updates a field data (tax, discount, ship) onto summary component;
1. Auto-generate summary metadata's (`Subtotal`, `Tax`, `Total`);

## Fixes:
1. Keep item's `input` (onto the cart table) value in sync with _local storage_ data persisted; (44dfead3efe1846c72cf67746ba1f3ad1f4c3cba)